### PR TITLE
feat: match configmap with release and project name

### DIFF
--- a/chart/values-production.yaml
+++ b/chart/values-production.yaml
@@ -17,7 +17,7 @@ podSecurityContext: {}
 securityContext: {}
 
 config:
-  ConfigMap: demo-server
+  ConfigMap: demo-server-prod
 
 service:
   type: ClusterIP


### PR DESCRIPTION
### Description:
Due to the limitation of using a pre-packaged configmap chart, the config map name needs to always match with the release name and the ArgoCD project name.